### PR TITLE
Fix "--comments" command line option

### DIFF
--- a/fbi.c
+++ b/fbi.c
@@ -1371,6 +1371,7 @@ int main(int argc, char *argv[])
     autodown    = GET_AUTO_DOWN();
     fitwidth    = GET_FIT_WIDTH();
     statusline  = GET_VERBOSE();
+    comments    = GET_COMMENTS();
     textreading = GET_TEXT_MODE();
     editable    = GET_EDIT();
     backup      = GET_BACKUP();


### PR DESCRIPTION
The  "--comments" command line wasn't working for me.
This is a simple fix proposal.